### PR TITLE
Persist ts-node-dev watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "!build:docker": "docker build -t $npm_package_name:$npm_package_version .",
     "build": "npm run !build:tsc",
     "start": "node ./$npm_package_config_dist",
-    "start:dev": "cross-env NODE_ENV=development ts-node-dev -r tsconfig-paths/register -r dotenv/config ./$npm_package_config_src",
+    "start:dev": "cross-env NODE_ENV=development ts-node-dev --respawn -r tsconfig-paths/register -r dotenv/config ./$npm_package_config_src",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0"
   }
 }


### PR DESCRIPTION
Ts-node-dev will exit if the target application gracefully exits.

Adding --respawn will persist the instance and continue watching for changes.