### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,36 @@
-FROM node:lts-alpine
+# Thank you BretFisher
+# https://github.com/BretFisher/nodejs-rocks-in-docker
 
+FROM node:16.14.2-slim as node
 WORKDIR /app
-COPY . /app
-
+COPY --chown=node:node package*.json yarn*.lock ./
 RUN npm install
-RUN npm run build
-RUN rm -rf src
-RUN npm prune --production
+COPY --chown=node:node . .
+RUN npm run \!build:tsc
 
-ENV NODE_ENV=PRODUCTION
+FROM ubuntu:focal-20220404 as base
+RUN apt-get update \
+    && apt-get -qq install -y --no-install-recommends \
+    tini \
+    && rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["/usr/bin/tini", "--"]
 
-CMD ["npm", "run-script", "start"]
+COPY --from=node /usr/local/include/ /usr/local/include/
+COPY --from=node /usr/local/lib/ /usr/local/lib/
+COPY --from=node /usr/local/bin/ /usr/local/bin/
+RUN corepack disable && corepack enable
+
+RUN groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \
+    && mkdir /app \
+    && chown -R node:node /app
+
+FROM base as prod
+WORKDIR /app
+COPY --from=node /app/build /app/build
+RUN chown -R node:node /app/build/*
+USER node
+COPY --chown=node:node package*.json yarn*.lock ./
+RUN npm ci --only=production && npm cache clean --force
+
+CMD ["node", "./build/index.js"]


### PR DESCRIPTION
Following BretFisher's "Node.js Rocks in Docker" during DockerCon 2022, use docker multi-stage builds to create a minimal and secure container for running a production level application.

DockerCon 2022 Presentation Video:
https://www.youtube.com/watch?v=Z0lpNSC1KbM

Examples Repo:
https://github.com/BretFisher/nodejs-rocks-in-docker